### PR TITLE
Fix inventory pom.xml and add a module level pom

### DIFF
--- a/m4/inventory-service/pom.xml
+++ b/m4/inventory-service/pom.xml
@@ -33,7 +33,6 @@
       <artifactId>quarkus-resteasy-reactive</artifactId>
     </dependency>
     <dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>

--- a/m4/pom.xml
+++ b/m4/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.coolstore</groupId>
+    <artifactId>coolstore</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>cart-service</module>
+        <module>catalog-service</module>
+        <module>inventory-service</module>
+        <module>order-service</module>
+        <module>payment-service</module>
+    </modules>
+</project>


### PR DESCRIPTION
This fixes the inventory service pom compilation error. 
Also adds a new pom.xml on the m4 level to make it easier to compile all services. excluding the Node front-end.